### PR TITLE
Move to API version v10.08 from v1 (v10.04)

### DIFF
--- a/PowerArubaCX/Private/RestMethod.ps1
+++ b/PowerArubaCX/Private/RestMethod.ps1
@@ -40,9 +40,9 @@ function Invoke-ArubaCXRestMethod {
       Invoke-RestMethod with ArubaCX connection for get rest/vX/system with display only attributes hostname and dns_servers
 
       .EXAMPLE
-      Invoke-ArubaCXRestMethod -method "get" -uri "rest/v10.04/system" -noapiversion
+      Invoke-ArubaCXRestMethod -method "get" -uri "rest/v10.08/system" -noapiversion
 
-      Invoke-RestMethod with ArubaCX connection for get rest/v10.04/system (need to specify full uri with rest/vX)
+      Invoke-RestMethod with ArubaCX connection for get rest/v10.08/system (need to specify full uri with rest/vX)
     #>
 
     [CmdletBinding(DefaultParametersetname = "default")]

--- a/PowerArubaCX/Public/Connection.ps1
+++ b/PowerArubaCX/Public/Connection.ps1
@@ -93,7 +93,7 @@ function Connect-ArubaCX {
         }
 
         $postParams = @{username = $Credential.username; password = $Credential.GetNetworkCredential().Password }
-        $url = "https://${Server}:${Port}/rest/v1/login"
+        $url = "https://${Server}:${Port}/rest/v10.08/login"
         try {
             Invoke-RestMethod $url -Method POST -Body $postParams -SessionVariable arubacx @invokeParams | Out-Null
         }
@@ -107,7 +107,7 @@ function Connect-ArubaCX {
             $rest = Invoke-RestMethod $url -Method "get" -WebSession $arubacx @invokeParams
         }
         catch {
-            throw "Unsupported release Need to use ArubaCX >= 10.04"
+            throw "Unsupported release Need to use ArubaCX >= 10.08"
         }
 
         $connection.server = $server

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There is some extra feature
 
 More functionality will be added later.
 
-Tested with ArubaCX 8400 and 832x, 6x00 (using >= 10.04.xx firmware) on Windows/Linux/macOS
+Tested with ArubaCX 8400 and 832x, 6x00 (using >= 10.08.xx firmware) on Windows/Linux/macOS
 
 # Usage
 
@@ -39,7 +39,7 @@ For example, you can manage Vlans with the following commands:
 # Requirements
 
 - Powershell 6 (Core) or 5 (If possible get the latest version)
-- An ArubaCX Switch (with firmware >= 10.04.xx) and REST API enable
+- An ArubaCX Switch (with firmware >= 10.08.xx) and REST API enable
 
 # Instructions
 ### Install the module

--- a/Tests/integration/Connection.Tests.ps1
+++ b/Tests/integration/Connection.Tests.ps1
@@ -47,7 +47,7 @@ Describe "Connect to a switch (using multi connection)" {
     }
 
     It "Throw when try to use Invoke-ArubaCPRestMethod and not connected" {
-        { Invoke-ArubaCXRestMethod -uri "rest/v1/system" } | Should -Throw "Not Connected. Connect to the Switch with Connect-ArubaCX"
+        { Invoke-ArubaCXRestMethod -uri "rest/v10.08/system" } | Should -Throw "Not Connected. Connect to the Switch with Connect-ArubaCX"
     }
 
     Context "Use Multi connection for call some (Get) cmdlet (Vlan, System...)" {


### PR DESCRIPTION
Updated code, tests to use api version v10.08 instead of v1 (v10.04) as it is removed from firmware version v10.12 and a 410 Gone message is received.
Release Notes: https://www.arubanetworks.com/techdocs/AOS-CX/10.12/RN/rn_6300-6400_10-12-0006.pdf
Page 10:
The REST v1 API are not supported in AOS-CX 10.10 or later releases.
However, when users made REST v1 requests, they would get expected
responses.  As of 10.12, REST v1 will be deactivated, so any REST v1 calls
made to the switches will no longer give a 200 or 201 response, and will be
forbidden.  Network admins that previous used REST v1 calls must update
them to use later REST versions